### PR TITLE
Jacoco reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ hs_err_pid*
 
 # Eclipse
 .settings
+.project
 eclipse.sh
 
 # IDEA

--- a/com.salesforce.b2eclipse.report/pom.xml
+++ b/com.salesforce.b2eclipse.report/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.salesforce.b2eclipse</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>com.salesforce.b2eclipse.report</artifactId>
+    <name>${base.name} :: Report</name>
+    <packaging>pom</packaging>
+    
+    <profiles>
+		<profile>
+			<id>jacoco</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco-version}</version>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>report-aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+    <dependencies>
+	    <dependency>
+	      <groupId>com.salesforce.b2eclipse</groupId>
+	      <artifactId>com.salesforce.b2eclipse.jdt.ls</artifactId>
+	      <version>${project.version}</version>
+	      <scope>compile</scope>
+	    </dependency>
+	    <dependency>
+	      <groupId>com.salesforce.b2eclipse</groupId>
+	      <artifactId>com.salesforce.b2eclipse.tests</artifactId>
+	      <version>${project.version}</version>
+	      <scope>test</scope>
+	    </dependency>
+  </dependencies>
+</project>

--- a/com.salesforce.b2eclipse.tests/pom.xml
+++ b/com.salesforce.b2eclipse.tests/pom.xml
@@ -20,8 +20,6 @@
                     <artifactId>tycho-surefire-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
-                        <argLine>${tycho.testArgLine} ${os.testArgs}</argLine>
-                        <runOrder>random</runOrder>
                         <explodedBundles>
 	                        <explodedBundle>com.salesforce.b2eclipse.jdt.ls</explodedBundle>
                     	</explodedBundles>
@@ -30,37 +28,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <profiles>
-        <profile>
-            <id>macosx-jvm-flags</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-            <properties>
-                <os.testArgs>-XstartOnFirstThread -noverify</os.testArgs>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.eclipse.tycho</groupId>
-                            <artifactId>tycho-surefire-plugin</artifactId>
-                            <version>${tycho-version}</version>
-                            <configuration>
-                                <dependencies>
-                                    <dependency>
-                                        <artifactId>org.eclipse.jdt</artifactId>
-                                        <version>0.0.0</version>
-                                        <type>eclipse-feature</type>
-                                    </dependency>
-                                </dependencies>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,6 @@
         <tycho-version>1.6.0</tycho-version>
         <tycho-extras-version>${tycho-version}</tycho-extras-version>
         <tycho.scmUrl>scm:git:https://github.com/salesforce/bazel-eclipse-ls</tycho.scmUrl>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-        <coverage.filter>com.salesforce.b2eclipse.*</coverage.filter>
-        <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
-        <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
-        <!-- To handle OSX-specific settings -->
-        <os.testArgs></os.testArgs>
     </properties>
     <modules>
         <module>com.salesforce.b2eclipse.jdt.ls</module>
@@ -41,22 +35,6 @@
     </modules>
     <build>
         <plugins>
-            <!--<plugin>
-                <groupId>com.fizzed</groupId>
-                <artifactId>fizzed-watcher-maven-plugin</artifactId>
-                <version>1.0.6</version>
-                <configuration>
-                    <watches>
-                        <watch>
-                            <directory>org.eclipse.jdt.ls.core/src</directory>
-                        </watch>
-                    </watches>
-                    <goals>
-                        <goal>clean</goal>
-                        <goal>verify</goal>
-                    </goals>
-                </configuration>
-            </plugin>-->
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-packaging-plugin</artifactId>
@@ -185,55 +163,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>plugin</id>
-            <activation>
-                <!-- Enable jacoco only on plugin projects -->
-                <file>
-                    <exists>META-INF/MANIFEST.MF</exists>
-                </file>
-            </activation>
-            <properties>
-                <jacoco.destFile>${project.basedir}/../target/jacoco.exec</jacoco.destFile>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.tycho</groupId>
-                        <artifactId>tycho-source-plugin</artifactId>
-                        <version>${tycho-version}</version>
-                        <executions>
-                            <execution>
-                                <id>plugin-source</id>
-                                <goals>
-                                    <goal>plugin-source</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                                <configuration>
-                                    <sessionId>${project.artifactId}</sessionId>
-                                    <includes>
-                                        <include>${coverage.filter}</include>
-                                    </includes>
-                                    <!-- Merge reports from all executions -->
-                                    <append>true</append>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,93 @@
         <tycho-version>1.6.0</tycho-version>
         <tycho-extras-version>${tycho-version}</tycho-extras-version>
         <tycho.scmUrl>scm:git:https://github.com/salesforce/bazel-eclipse-ls</tycho.scmUrl>
+        <jacoco-version>0.8.3</jacoco-version>
     </properties>
     <modules>
         <module>com.salesforce.b2eclipse.jdt.ls</module>
         <module>com.salesforce.b2eclipse.repository</module>
         <module>com.salesforce.b2eclipse.tests</module>
         <module>com.salesforce.b2eclipse.ui</module>
+        <module>com.salesforce.b2eclipse.report</module>
     </modules>
+    
+    <profiles>
+		<profile>
+			<id>jacoco</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco-version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+		        <plugins>
+		            <plugin>
+		                <groupId>org.eclipse.tycho.extras</groupId>
+		                <artifactId>tycho-pack200a-plugin</artifactId>
+		                <version>${tycho-version}</version>
+		                <executions>
+		                    <execution>
+		                        <id>pack200-normalize</id>
+		                        <goals>
+		                            <goal>normalize</goal>
+		                        </goals>
+		                        <phase>package</phase>
+		                    </execution>
+		                </executions>
+		            </plugin>
+		            <plugin>
+		                <groupId>org.eclipse.tycho.extras</groupId>
+		                <artifactId>tycho-pack200b-plugin</artifactId>
+		                <version>${tycho-version}</version>
+		                <executions>
+		                    <execution>
+		                        <id>pack200-pack</id>
+		                        <goals>
+		                            <goal>pack</goal>
+		                        </goals>
+		                        <phase>package</phase>
+		                    </execution>
+		                </executions>
+		            </plugin>
+		            <plugin>
+		                <groupId>org.eclipse.tycho</groupId>
+		                <artifactId>tycho-p2-plugin</artifactId>
+		                <version>${tycho-version}</version>
+		                <executions>
+		                    <execution>
+		                        <id>p2-metadata</id>
+		                        <goals>
+		                            <goal>p2-metadata</goal>
+		                        </goals>
+		                        <phase>package</phase>
+		                    </execution>
+		                </executions>
+		                <configuration>
+		                    <defaultP2Metadata>false</defaultP2Metadata>
+		                </configuration>
+		            </plugin>
+            	</plugins>
+            </build>
+		</profile>
+	</profiles>
+    
     <build>
         <plugins>
             <plugin>
@@ -51,52 +131,6 @@
                     <jgit.ignore>
                         pom.xml
                     </jgit.ignore>
-                </configuration>
-            </plugin>
-            <!-- Those 4 mojos are for signing and packing -->
-            <plugin>
-                <groupId>org.eclipse.tycho.extras</groupId>
-                <artifactId>tycho-pack200a-plugin</artifactId>
-                <version>${tycho-version}</version>
-                <executions>
-                    <execution>
-                        <id>pack200-normalize</id>
-                        <goals>
-                            <goal>normalize</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.eclipse.tycho.extras</groupId>
-                <artifactId>tycho-pack200b-plugin</artifactId>
-                <version>${tycho-version}</version>
-                <executions>
-                    <execution>
-                        <id>pack200-pack</id>
-                        <goals>
-                            <goal>pack</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.eclipse.tycho</groupId>
-                <artifactId>tycho-p2-plugin</artifactId>
-                <version>${tycho-version}</version>
-                <executions>
-                    <execution>
-                        <id>p2-metadata</id>
-                        <goals>
-                            <goal>p2-metadata</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
-                <configuration>
-                    <defaultP2Metadata>false</defaultP2Metadata>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
# Related Issue
- (Closes #48) Add JaCoCo coverage report

# Proposed Changes
- Get rid of unused maven plugins, properties
- Add support for JaCoCo reports (separate maven profile)

# Additional Info
- Plugins related to p2 signing were moved to a separate profile which is activated by default. Reason: seems that tycho-pack200a-plugin modifies class files and this causes JaCoCo reports to be incorrect (0% coverage). JaCoCo assumes no modifications are made to classes at runtime (https://www.eclemma.org/jacoco/trunk/doc/classids.html) 
