### PR TITLE
Separation properties files of initialization params and others plugin properties

### DIFF
--- a/com.salesforce.b2eclipse.ui/src/main/resources/init_params.properties
+++ b/com.salesforce.b2eclipse.ui/src/main/resources/init_params.properties
@@ -1,0 +1,4 @@
+java.import.bazel.enabled=true
+java.import.maven.enabled=false
+java.import.bazel.src.path=/java/src
+java.import.bazel.test.path=/java/test

--- a/com.salesforce.b2eclipse.ui/src/main/resources/plugin.properties
+++ b/com.salesforce.b2eclipse.ui/src/main/resources/plugin.properties
@@ -1,7 +1,2 @@
 # JDTLS connection provider params
 connectionProvider.socket.port=5036
-
-# JDTLS init params
-java.import.bazel.enabled=true
-java.import.bazel.src.path=/java/src
-java.import.bazel.test.path=/java/test


### PR DESCRIPTION
# Related Issue
- (closes #53 ) Separation properties files of initialization params and others plugin properties

# Proposed Changes
- Separation properties files of initialization params and others plugin properties
- Set property for disable MavenProjectImporter in JDT LS

# Additional Info
- java.import.maven.enabled=false disable MavenProjectImporter in JDT LS
