### PR TITLE
Set org.eclipse.jdt.ls.core version=0.0.0

### DIFF
--- a/com.salesforce.b2eclipse.jdt.ls/com.salesforce.b2eclipse.jdt.ls.target
+++ b/com.salesforce.b2eclipse.jdt.ls/com.salesforce.b2eclipse.jdt.ls.target
@@ -39,7 +39,7 @@
         </location>
 	    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		    <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
-		    <unit id="org.eclipse.jdt.ls.core" version="0.54.0.202004081320"/>
+		    <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
 	    </location>
 	    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		    <repository location="http://download.eclipse.org/scout/releases/4.0/testing"/>


### PR DESCRIPTION
# Related Issue
- (closes #66) Remove version dependency for org.eclipse.jdt.ls.core in target file

# Proposed Changes
- Set org.eclipse.jdt.ls.core version=0.0.0 in target file
