### PR TITLE
Extract bundle resources to a cache

### DIFF
--- a/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/config/BazelAspectLocationImpl.java
+++ b/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/b2eclipse/config/BazelAspectLocationImpl.java
@@ -63,7 +63,7 @@ public class BazelAspectLocationImpl implements BazelAspectLocation {
                         "Eclipse OSGi subsystem could not find the core plugin [" + BazelJdtPlugin.PLUGIN_ID + "]");
             }
             URL url = bazelCorePlugin.getEntry("resources");
-            URL resolved = FileLocator.resolve(url);
+            URL resolved = FileLocator.toFileURL(url);
             if (resolved == null) {
                 throw new IllegalStateException("Could not load location [" + url + "]");
             }

--- a/com.salesforce.b2eclipse.tests/pom.xml
+++ b/com.salesforce.b2eclipse.tests/pom.xml
@@ -11,21 +11,4 @@
     <artifactId>com.salesforce.b2eclipse.tests</artifactId>
     <name>${base.name} :: Tests</name>
     <packaging>eclipse-test-plugin</packaging>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.eclipse.tycho</groupId>
-                    <artifactId>tycho-surefire-plugin</artifactId>
-                    <version>${tycho-version}</version>
-                    <configuration>
-                        <explodedBundles>
-	                        <explodedBundle>com.salesforce.b2eclipse.jdt.ls</explodedBundle>
-                    	</explodedBundles>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>


### PR DESCRIPTION
# Proposed Changes
- Extract the contents of bundle's resource folder into a cache on the file-system in order to get a file URL which can be accessible by bazel executable
